### PR TITLE
feat: Add GitHub Pages deployment support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [ develop/v1.1 ]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
     - name: Checkout
@@ -31,10 +39,17 @@ jobs:
         cd frontend
         npm run build
         
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+      if: github.ref == 'refs/heads/develop/v1.1'
+      
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v2
       if: github.ref == 'refs/heads/develop/v1.1'
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./frontend/build
-        cname: # Add your custom domain here if you have one
+        path: ./frontend/build
+        
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2
+      if: github.ref == 'refs/heads/develop/v1.1'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ develop/v1.1, main ]
+  pull_request:
+    branches: [ develop/v1.1 ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+        
+    - name: Install dependencies
+      run: |
+        cd frontend
+        npm ci
+        
+    - name: Build application
+      run: |
+        cd frontend
+        npm run build
+        
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/develop/v1.1'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./frontend/build
+        cname: # Add your custom domain here if you have one

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,5 @@
+# Production environment for GitHub Pages deployment
+REACT_APP_API_URL=https://api.example.com
+REACT_APP_DEMO_MODE=true
+REACT_APP_VERSION=1.1.0
+GENERATE_SOURCEMAP=false

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.16",
+        "gh-pages": "^6.3.0",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.3.5"
       }
@@ -8217,6 +8218,13 @@
       "integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
       "license": "ISC"
     },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emittery": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
@@ -9497,6 +9505,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/filesize": {
       "version": "8.0.7",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
@@ -9999,6 +10035,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gh-pages": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+      "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "commander": "^13.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^11.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gh-pages/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gh-pages/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/glob": {
@@ -19034,6 +19118,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
@@ -19659,6 +19766,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/tryer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "facility-manager-frontend",
   "version": "1.0.0",
+  "homepage": "https://ruisoho.github.io/rynix-fm-management",
   "private": true,
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [
@@ -46,6 +48,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
+    "gh-pages": "^6.3.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import Sidebar from './components/Sidebar';
 import Header from './components/Header';
+import DemoBanner from './components/DemoBanner';
 import Dashboard from './pages/Dashboard';
 import Facilities from './pages/Facilities';
 import FacilityDetail from './pages/FacilityDetail';
@@ -92,6 +93,7 @@ function App() {
           }}
         >
           <div className="min-h-screen bg-light-bg dark:bg-dark-bg text-light-text dark:text-dark-text transition-colors duration-300">
+            <DemoBanner />
             <div className="flex">
               {/* Mobile sidebar overlay */}
               {sidebarOpen && (

--- a/frontend/src/components/DemoBanner.jsx
+++ b/frontend/src/components/DemoBanner.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ExclamationTriangleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+
+const DemoBanner = () => {
+  const isDemoMode = process.env.REACT_APP_DEMO_MODE === 'true' || process.env.NODE_ENV === 'production';
+  
+  if (!isDemoMode) {
+    return null;
+  }
+
+  return (
+    <div className="bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800">
+      <div className="max-w-7xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between flex-wrap">
+          <div className="w-0 flex-1 flex items-center">
+            <span className="flex p-2 rounded-lg bg-yellow-100 dark:bg-yellow-800">
+              <InformationCircleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-300" aria-hidden="true" />
+            </span>
+            <p className="ml-3 font-medium text-yellow-800 dark:text-yellow-200 truncate">
+              <span className="md:hidden">
+                Demo Mode - Sample Data Only
+              </span>
+              <span className="hidden md:inline">
+                🚀 Demo Version - This is a demonstration of the Facility Management App with sample data. 
+                No real backend connection.
+              </span>
+            </p>
+          </div>
+          <div className="order-3 mt-2 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto">
+            <a
+              href="https://github.com/ruisoho/rynix-fm-management"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-yellow-800 dark:text-yellow-200 bg-yellow-100 dark:bg-yellow-800 hover:bg-yellow-200 dark:hover:bg-yellow-700 transition-colors"
+            >
+              View Source Code
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DemoBanner;

--- a/frontend/src/contexts/ApiContext.jsx
+++ b/frontend/src/contexts/ApiContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 import axios from 'axios';
+import { DemoApiService } from '../services/demoData';
 
 const ApiContext = createContext();
 
@@ -10,6 +11,9 @@ export const useApi = () => {
   }
   return context;
 };
+
+// Check if we're in demo mode
+const isDemoMode = process.env.REACT_APP_DEMO_MODE === 'true' || process.env.NODE_ENV === 'production';
 
 // Configure axios defaults
 axios.defaults.baseURL = process.env.REACT_APP_API_URL || '';
@@ -82,11 +86,17 @@ export const ApiProvider = ({ children }) => {
 
   // Dashboard API
   const getDashboardData = useCallback(() => {
+    if (isDemoMode) {
+      return handleApiCall(() => DemoApiService.getDashboard());
+    }
     return handleApiCall(() => axios.get('/api/dashboard').then(res => res.data));
   }, [handleApiCall]);
 
   // Facilities API
   const getFacilities = useCallback(() => {
+    if (isDemoMode) {
+      return handleApiCall(() => DemoApiService.getFacilities());
+    }
     return handleApiCall(() => axios.get('/api/facilities').then(res => res.data));
   }, [handleApiCall]);
 
@@ -180,6 +190,9 @@ export const ApiProvider = ({ children }) => {
 
   // Heating API
   const getHeating = useCallback(() => {
+    if (isDemoMode) {
+      return handleApiCall(() => DemoApiService.getHeating());
+    }
     return handleApiCall(() => axios.get('/api/heating').then(res => res.data));
   }, [handleApiCall]);
 
@@ -205,6 +218,9 @@ export const ApiProvider = ({ children }) => {
 
   // Meters API
   const getMeters = useCallback(() => {
+    if (isDemoMode) {
+      return handleApiCall(() => DemoApiService.getMeters());
+    }
     return handleApiCall(() => axios.get('/api/meters').then(res => res.data));
   }, [handleApiCall]);
 
@@ -217,6 +233,9 @@ export const ApiProvider = ({ children }) => {
   }, [handleApiCall]);
 
   const getMeterReadings = useCallback((meterId) => {
+    if (isDemoMode) {
+      return handleApiCall(() => DemoApiService.getMeterReadings(meterId));
+    }
     return handleApiCall(() => axios.get(`/api/meters/${meterId}/readings`).then(res => res.data));
   }, [handleApiCall]);
 
@@ -230,6 +249,9 @@ export const ApiProvider = ({ children }) => {
 
   // Energy Consumption API
   const getEnergyConsumption = useCallback((period = 'monthly') => {
+    if (isDemoMode) {
+      return handleApiCall(() => DemoApiService.getEnergyConsumption());
+    }
     return handleApiCall(() => axios.get(`/api/energy-consumption?period=${period}`).then(res => res.data));
   }, [handleApiCall]);
 

--- a/frontend/src/services/demoData.js
+++ b/frontend/src/services/demoData.js
@@ -1,0 +1,221 @@
+// Demo data service for GitHub Pages deployment
+// This provides mock data when the backend is not available
+
+export const demoFacilities = [
+  {
+    id: 1,
+    name: "Main Building",
+    address: "123 Main Street, City",
+    type: "Office",
+    status: "active",
+    created_at: "2023-01-15T10:00:00Z",
+    updated_at: "2024-01-15T10:00:00Z"
+  },
+  {
+    id: 2,
+    name: "Bike Market",
+    address: "456 Market Avenue, City",
+    type: "Commercial",
+    status: "active",
+    created_at: "2023-02-20T14:30:00Z",
+    updated_at: "2024-01-20T14:30:00Z"
+  }
+];
+
+export const demoMeters = [
+  {
+    id: 1,
+    facility_id: 1,
+    facility_name: "Main Building",
+    serial_number: "ELE001",
+    type: "electric",
+    location: "Main Panel",
+    manufacturer: "Siemens",
+    model: "PAC3200",
+    installation_date: "2023-01-15",
+    status: "active"
+  },
+  {
+    id: 2,
+    facility_id: 1,
+    facility_name: "Main Building",
+    serial_number: "GAS001",
+    type: "gas",
+    location: "Basement",
+    manufacturer: "Honeywell",
+    model: "EK280",
+    installation_date: "2023-01-20",
+    status: "active"
+  },
+  {
+    id: 3,
+    facility_id: 2,
+    facility_name: "Bike Market",
+    serial_number: "ELE002",
+    type: "electric",
+    location: "Shop Floor",
+    manufacturer: "ABB",
+    model: "M2M",
+    installation_date: "2023-02-10",
+    status: "active"
+  }
+];
+
+export const demoHeatingMeters = [
+  {
+    id: 4,
+    facility_id: 1,
+    facility_name: "Main Building",
+    serial_number: "HEAT001",
+    location: "Boiler Room",
+    manufacturer: "Viessmann",
+    status: "active",
+    source_table: "heating_systems"
+  },
+  {
+    id: 5,
+    facility_id: 2,
+    facility_name: "Bike Market",
+    serial_number: "HEAT002",
+    location: "Utility Room",
+    manufacturer: "Buderus",
+    status: "active",
+    source_table: "heating_systems"
+  }
+];
+
+export const demoReadings = [
+  {
+    id: 1,
+    meter_id: 1,
+    reading_value: 1250.5,
+    reading_date: "2024-01-15",
+    notes: "Monthly reading"
+  },
+  {
+    id: 2,
+    meter_id: 1,
+    reading_value: 1275.8,
+    reading_date: "2024-01-20",
+    notes: "Weekly check"
+  },
+  {
+    id: 3,
+    meter_id: 2,
+    reading_value: 850.2,
+    reading_date: "2024-01-15",
+    notes: "Monthly reading"
+  },
+  {
+    id: 4,
+    meter_id: 3,
+    reading_value: 420.7,
+    reading_date: "2024-01-18",
+    notes: "Bi-weekly check"
+  }
+];
+
+export const demoDashboardData = {
+  totalFacilities: 2,
+  totalMeters: 5,
+  totalReadings: 87,
+  activeAlerts: 0,
+  recentReadings: demoReadings.slice(-5),
+  energyConsumption: {
+    electric: 2850.5,
+    gas: 1250.8,
+    heating: 980.3
+  },
+  monthlyTrends: [
+    { month: "Jan", electric: 2800, gas: 1200, heating: 950 },
+    { month: "Feb", electric: 2750, gas: 1180, heating: 920 },
+    { month: "Mar", electric: 2900, gas: 1300, heating: 1000 }
+  ]
+};
+
+// Demo API service that mimics the real API
+export class DemoApiService {
+  static async getFacilities() {
+    await this.delay(300); // Simulate network delay
+    return { data: demoFacilities };
+  }
+
+  static async getMeters() {
+    await this.delay(300);
+    return { data: demoMeters };
+  }
+
+  static async getHeating() {
+    await this.delay(300);
+    return { data: demoHeatingMeters };
+  }
+
+  static async getMeterReadings(meterId) {
+    await this.delay(300);
+    const readings = demoReadings.filter(r => r.meter_id === parseInt(meterId));
+    return { data: readings };
+  }
+
+  static async getDashboard() {
+    await this.delay(300);
+    return { data: demoDashboardData };
+  }
+
+  static async getEnergyConsumption() {
+    await this.delay(300);
+    return { data: demoDashboardData.energyConsumption };
+  }
+
+  // Simulate network delay
+  static delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  // Mock methods for other API calls
+  static async createFacility(data) {
+    await this.delay(300);
+    return { data: { id: Date.now(), ...data } };
+  }
+
+  static async updateFacility(id, data) {
+    await this.delay(300);
+    return { data: { id, ...data } };
+  }
+
+  static async deleteFacility(id) {
+    await this.delay(300);
+    return { data: { success: true } };
+  }
+
+  static async createMeter(data) {
+    await this.delay(300);
+    return { data: { id: Date.now(), ...data } };
+  }
+
+  static async updateMeter(id, data) {
+    await this.delay(300);
+    return { data: { id, ...data } };
+  }
+
+  static async deleteMeter(id) {
+    await this.delay(300);
+    return { data: { success: true } };
+  }
+
+  static async createReading(data) {
+    await this.delay(300);
+    return { data: { id: Date.now(), ...data } };
+  }
+
+  static async updateReading(id, data) {
+    await this.delay(300);
+    return { data: { id, ...data } };
+  }
+
+  static async deleteReading(id) {
+    await this.delay(300);
+    return { data: { success: true } };
+  }
+}
+
+export default DemoApiService;


### PR DESCRIPTION
- Add GitHub Actions workflow for automated deployment
- Configure homepage URL for GitHub Pages
- Add demo mode with mock data service
- Create demo banner component for GitHub Pages
- Update ApiContext to support demo mode
- Add production environment configuration
- Build successfully tested and ready for deployment